### PR TITLE
test: x-optic-path-ignore

### DIFF
--- a/src/api-docs/openapi-generator.ts
+++ b/src/api-docs/openapi-generator.ts
@@ -142,6 +142,7 @@ registry.registerPath({
 const generator = new OpenApiGeneratorV31(registry.definitions)
 export const openApiDoc = generator.generateDocument({
   openapi: '3.1.0',
+  'x-optic-path-ignore': '/__messages__', // these are tool specific paths, we don't need in api coverage
   info: {
     title: 'Movies API',
     version: '1.0.0',

--- a/src/api-docs/openapi.json
+++ b/src/api-docs/openapi.json
@@ -1,5 +1,6 @@
 {
   "openapi": "3.1.0",
+  "x-optic-path-ignore": "/__messages__",
   "info": {
     "title": "Movies API",
     "version": "1.0.0",

--- a/src/api-docs/openapi.yml
+++ b/src/api-docs/openapi.yml
@@ -61,9 +61,16 @@ components:
         error:
           type: string
           description: Error message, if any
+        id:
+          type: number
+        name:
+          type: string
+        year:
+          type: number
       required:
-        - status
-        - movie
+        - id
+        - name
+        - year
     GetMovieResponse:
       anyOf:
         - type: object
@@ -115,7 +122,8 @@ components:
           example: Movie {id} has been deleted
       required:
         - message
-  parameters: {}
+  parameters:
+    {}
 paths:
   /:
     get:
@@ -245,4 +253,5 @@ paths:
                 required:
                   - status
                   - error
-webhooks: {}
+webhooks:
+  {}

--- a/src/api-docs/openapi.yml
+++ b/src/api-docs/openapi.yml
@@ -1,4 +1,5 @@
 openapi: 3.1.0
+x-optic-path-ignore: /__messages__
 info:
   title: Movies API
   version: 1.0.0


### PR DESCRIPTION
```bash
# checkout the branch & install 
git clone git@github.com:muratkeremozcan/pact-js-example-provider.git
cd  pact-js-example-provider
git checkout  test/x-optic-path-ignore
npm i

npm start 
# new tab
npm run generate:openapi # creates openapi.yml
npm run optic:verify 
```

Although we add the `test/x-optic-path-ignore` for `/__messages__` to the root of the openapi.yml, during `optic:update` we still get a notification about it



<img width="847" alt="image" src="https://github.com/user-attachments/assets/bd623596-30f4-46fd-8ef2-0a8ea76b0470">
