### PR TITLE
test: buildVerifierOptions utility to simplify usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ PACT_PROVIDER_NO_STATE=true npm run test:provider
 To run tests from a certain consumer:
 
 ```bash
-PACT_CONSUMER="MoviesAPI" npm run test:provider
+PACT_CONSUMER="WebConsumer" npm run test:provider
 ```
 
 #### Handling Breaking Changes
@@ -204,7 +204,7 @@ PACT_BREAKING_CHANGE=true npm run test:provider
 In CI, you can enable this behavior by including a checkbox in the PR description. If the box is unchecked or not included, the `PACT_BREAKING_CHANGE` variable is set to `false`.
 
 ```readme
-- [x] Pact breaking change 
+- [x] Pact breaking change
 ```
 
 ## Consumer Tests

--- a/src/provider-contract.pacttest.ts
+++ b/src/provider-contract.pacttest.ts
@@ -1,39 +1,22 @@
-import type { VerifierOptions } from '@pact-foundation/pact'
 import { Verifier } from '@pact-foundation/pact'
 import { stateHandlers } from './test-helpers/state-handlers'
-import { buildConsumerVersionSelectors } from './test-helpers/pact-utils'
+import { buildVerifierOptions } from './test-helpers/pact-utils'
 
 // 1) Run the provider service
 // 2) Setup the provider verifier options
 // 3) Write & execute the provider contract test
 
-const port = process.env.PORT
+const port = process.env.PORT || '3001'
 
 describe('Pact Verification', () => {
   let verifier: Verifier
   beforeAll(async () => {
-    // Improve this with the pact setup at https://github.com/pactflow/example-provider/blob/master/src/product/product.consumerChange.pact.test.js
     // 2) Setup the provider verifier options
-    const options: VerifierOptions = {
+    const options = buildVerifierOptions({
       provider: 'MoviesAPI',
-      providerBaseUrl: `http://localhost:${port}`,
-      publishVerificationResult: true,
-      pactBrokerToken: process.env.PACT_BROKER_TOKEN as string,
-      providerVersion: process.env.GITHUB_SHA as string,
-      providerVersionBranch: process.env.GITHUB_BRANCH as string, // represents which contracts the provider should verify against
-      // logLevel: 'debug', // can be useful!
-
-      // PROVIDER STATES: we can simulate certain states of the API (like an empty or non-empty DB)
-      // in order to cover different scenarios
-      // The state could have many more variables; it is a good practice to represent it as an object
-      // Note that the consumer state name should match the provider side
-      //
-      // * The purpose of the stateHandlers is to ensure that the provider is in the correct state
-      // to fulfill the consumer's expectations as defined in the contract tests.
-      // * In a real-world scenario, you would typically set up this state by interacting with your service's database
-      // * or through an API provided by the service itself (locally).
-      // * This ensures that the provider test runs in a controlled environment where all the necessary data
-      // and conditions are met, allowing for accurate verification of the consumer's expectations.
+      consumer: process.env.PACT_CONSUMER, // filter by the consumer, or run for all if no env var is provided
+      includeMainAndDeployed: process.env.PACT_BREAKING_CHANGE !== 'true', // if it is a breaking change, set the env var
+      port,
       stateHandlers,
       beforeEach: () => {
         console.log('I run before each test coming from the consumer...')
@@ -43,50 +26,12 @@ describe('Pact Verification', () => {
         console.log('I run after each test coming from the consumer...')
         return Promise.resolve()
       }
-    }
-
-    // When the CI triggers the provider tests, we need to use the PACT_PAYLOAD_URL
-    // To use the PACT_PAYLOAD_URL, we need to update the provider options to use this URL instead.
-
-    if (process.env.PACT_PAYLOAD_URL) {
-      console.log(`Pact payload URL specified: ${process.env.PACT_PAYLOAD_URL}`)
-      options.pactUrls = [process.env.PACT_PAYLOAD_URL]
-    } else {
-      console.log(
-        `Using Pact Broker Base URL: ${process.env.PACT_BROKER_BASE_URL}`
-      )
-      options.pactBrokerUrl = process.env.PACT_BROKER_BASE_URL as string
-
-      // Environment variable to control exclusion of mainBranch and deployedOrReleased
-      const includeMainAndDeployed = process.env.PACT_BREAKING_CHANGE !== 'true'
-
-      const consumer = process.env.PACT_CONSUMER
-      options.consumerVersionSelectors = buildConsumerVersionSelectors(
-        consumer,
-        includeMainAndDeployed
-      )
-
-      if (consumer) {
-        console.log(`Running verification for consumer: ${consumer}`)
-      } else {
-        console.log('Running verification for all consumers')
-      }
-
-      if (includeMainAndDeployed) {
-        console.log(
-          'Including main branch and deployedOrReleased in the verification'
-        )
-      } else {
-        console.log(
-          'Only running the matching branch, this is useful when introducing breaking changes'
-        )
-      }
-    }
+    })
     verifier = new Verifier(options)
   })
 
   it('should validate the expectations of movie-consumer', async () => {
-    // 3) Write & execute the provider contract test (you have to return)
+    // 3) Write & execute the provider contract test
     const output = await verifier.verifyProvider()
     console.log('Pact Verification Complete!')
     console.log('Result:', output)
@@ -115,7 +60,7 @@ PACT_DESCRIPTION="a request to delete a movie that exists" PACT_PROVIDER_STATE="
 PACT_PROVIDER_NO_STATE=true npm run test:provider
 
 # to run tests from a certain consumer
-PACT_CONSUMER="MoviesAPI" npm run test:provider
+PACT_CONSUMER="WebConsumer" npm run test:provider
 
 # to relax the can:i:deploy and only check against matching branches
 PACT_BREAKING_CHANGE=true npm run test:provider

--- a/src/provider-contract.pacttest.ts
+++ b/src/provider-contract.pacttest.ts
@@ -6,29 +6,25 @@ import { buildVerifierOptions } from './test-helpers/pact-utils'
 // 2) Setup the provider verifier options
 // 3) Write & execute the provider contract test
 
-const port = process.env.PORT || '3001'
-
 describe('Pact Verification', () => {
-  let verifier: Verifier
-  beforeAll(async () => {
-    // 2) Setup the provider verifier options
-    const options = buildVerifierOptions({
-      provider: 'MoviesAPI',
-      consumer: process.env.PACT_CONSUMER, // filter by the consumer, or run for all if no env var is provided
-      includeMainAndDeployed: process.env.PACT_BREAKING_CHANGE !== 'true', // if it is a breaking change, set the env var
-      port,
-      stateHandlers,
-      beforeEach: () => {
-        console.log('I run before each test coming from the consumer...')
-        return Promise.resolve()
-      },
-      afterEach: () => {
-        console.log('I run after each test coming from the consumer...')
-        return Promise.resolve()
-      }
-    })
-    verifier = new Verifier(options)
+  // 2) Setup the provider verifier options
+  const port = process.env.PORT || '3001'
+  const options = buildVerifierOptions({
+    provider: 'MoviesAPI',
+    consumer: process.env.PACT_CONSUMER, // filter by the consumer, or run for all if no env var is provided
+    includeMainAndDeployed: process.env.PACT_BREAKING_CHANGE !== 'true', // if it is a breaking change, set the env var
+    port,
+    stateHandlers,
+    beforeEach: () => {
+      console.log('I run before each test coming from the consumer...')
+      return Promise.resolve()
+    },
+    afterEach: () => {
+      console.log('I run after each test coming from the consumer...')
+      return Promise.resolve()
+    }
   })
+  const verifier = new Verifier(options)
 
   it('should validate the expectations of movie-consumer', async () => {
     // 3) Write & execute the provider contract test

--- a/src/test-helpers/state-handlers.ts
+++ b/src/test-helpers/state-handlers.ts
@@ -77,13 +77,25 @@ export const stateHandlers: StateHandlers & MessageStateHandlers = {
   }
 }
 
-// Pact docs mention state setup and teardown
-// https://docs.pact.io/implementation_guides/javascript/docs/provider#provider-state-setup-and-teardown
-
-// but it doesn't work with TS at the moment
-// https://github.com/pact-foundation/pact-js/issues/1164
-
 /*
+ Note about PROVIDER STATES: we can simulate certain states of the API (like an empty or non-empty DB)
+ in order to cover different scenarios
+ The state could have many more variables; it is a good practice to represent it as an object
+ Note that the consumer state name should match the provider side
+
+ * The purpose of the stateHandlers is to ensure that the provider is in the correct state
+ to fulfill the consumer's expectations as defined in the contract tests.
+ * In a real-world scenario, you would typically set up this state by interacting with your service's database
+ * or through an API provided by the service itself (locally).
+ * This ensures that the provider test runs in a controlled environment where all the necessary data
+ and conditions are met, allowing for accurate verification of the consumer's expectations.
+
+Pact docs mention state setup and teardown
+https://docs.pact.io/implementation_guides/javascript/docs/provider#provider-state-setup-and-teardown
+
+but it doesn't work with TS at the moment
+https://github.com/pact-foundation/pact-js/issues/1164
+
 StateHandlers can either use:
 
 * a single function: this is only used for the setup phase, where you define a function that sets up the provider state. 


### PR DESCRIPTION
Refactored the test suite to include a new helper function buildVerifierOptions. 

This function centralizes the logic for configuring Pact verifier options, making the test setup more modular and reusable across different providers.

