### PR TITLE
experiment: optimize get response

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "deepscan.ignoreConfirmWarning": true
+}

--- a/cypress/index.d.ts
+++ b/cypress/index.d.ts
@@ -1,6 +1,14 @@
 import type { UserData } from './support/register-login-user'
 import type { Movie } from '@prisma/client'
 import type { OpenAPIV31 } from 'openapi-types'
+import type {
+  UpdateMovieResponse,
+  CreateMovieResponse,
+  MovieNotFoundResponse,
+  ConflictMovieResponse,
+  GetMovieResponse,
+  DeleteMovieResponse
+} from './@types'
 
 export {}
 
@@ -12,9 +20,7 @@ declare global {
        * cy.getAllMovies()
        * ```
        */
-      getAllMovies(
-        allowedToFail?: boolean
-      ): Chainable<Response<Movie[]> & Messages>
+      getAllMovies(allowedToFail?: boolean): Chainable<GetMovieResponse>
 
       /** Gets a movie by id
        * ```js
@@ -24,7 +30,7 @@ declare global {
       getMovieById(
         id: number,
         allowedToFail?: boolean
-      ): Chainable<Response<Movie> & Messages>
+      ): Chainable<GetMovieResponse>
 
       /** Gets a movie by name
        * ```js
@@ -34,7 +40,7 @@ declare global {
       getMovieByName(
         name: string,
         allowedToFail?: boolean
-      ): Chainable<Response<Movie> & Messages>
+      ): Chainable<GetMovieResponse>
 
       /** Creates a movie
        * ```js
@@ -44,7 +50,7 @@ declare global {
       addMovie(
         body: Omit<Movie, 'id'>,
         allowedToFail?: boolean
-      ): Chainable<Response<Omit<Movie, 'id'>> & Messages>
+      ): Chainable<CreateMovieResponse>
 
       /** Updates a movie by id
        * ```js
@@ -54,7 +60,7 @@ declare global {
       updateMovie(
         id: number,
         body: Partial<Movie>
-      ): Chainable<Response<Movie> & Messages>
+      ): Chainable<UpdateMovieResponse>
 
       /** Deletes a movie
        * ```js
@@ -64,7 +70,7 @@ declare global {
       deleteMovie(
         id: number,
         allowedToFail?: boolean
-      ): Chainable<Response<Movie> & Messages>
+      ): Chainable<DeleteMovieResponse>
 
       /**
        * Validates the response body against the provided schema.

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -5,35 +5,41 @@ import type { Movie } from '@prisma/client'
 
 Cypress.Commands.add('getAllMovies', (allowedToFail = false) => {
   cy.log('**getAllMovies**')
-  return cy.api({
-    method: 'GET',
-    url: '/movies',
-    retryOnStatusCodeFailure: !allowedToFail,
-    failOnStatusCode: !allowedToFail
-  })
+  return cy
+    .api({
+      method: 'GET',
+      url: '/movies',
+      retryOnStatusCodeFailure: !allowedToFail,
+      failOnStatusCode: !allowedToFail
+    })
+    .its('body')
 })
 
 Cypress.Commands.add('getMovieById', (id: number, allowedToFail = false) => {
   cy.log(`**getMovieById: ${id}**`)
-  return cy.api({
-    method: 'GET',
-    url: `/movies/${id}`,
-    retryOnStatusCodeFailure: !allowedToFail,
-    failOnStatusCode: !allowedToFail
-  })
+  return cy
+    .api({
+      method: 'GET',
+      url: `/movies/${id}`,
+      retryOnStatusCodeFailure: !allowedToFail,
+      failOnStatusCode: !allowedToFail
+    })
+    .its('body')
 })
 
 Cypress.Commands.add(
   'getMovieByName',
   (name: string, allowedToFail = false) => {
     cy.log(`**getMovieByName: ${name}**`)
-    return cy.api({
-      method: 'GET',
-      url: '/movies',
-      qs: { name },
-      retryOnStatusCodeFailure: !allowedToFail,
-      failOnStatusCode: !allowedToFail
-    })
+    return cy
+      .api({
+        method: 'GET',
+        url: '/movies',
+        qs: { name },
+        retryOnStatusCodeFailure: !allowedToFail,
+        failOnStatusCode: !allowedToFail
+      })
+      .its('body')
   }
 )
 
@@ -41,13 +47,15 @@ Cypress.Commands.add(
   'addMovie',
   (body: Omit<Movie, 'id'>, allowedToFail = false) => {
     cy.log('**addMovie**')
-    return cy.api({
-      method: 'POST',
-      url: '/movies',
-      body: body,
-      retryOnStatusCodeFailure: !allowedToFail,
-      failOnStatusCode: !allowedToFail
-    })
+    return cy
+      .api({
+        method: 'POST',
+        url: '/movies',
+        body: body,
+        retryOnStatusCodeFailure: !allowedToFail,
+        failOnStatusCode: !allowedToFail
+      })
+      .its('body')
   }
 )
 
@@ -56,22 +64,26 @@ Cypress.Commands.add(
   'updateMovie',
   (id: number, body: Partial<Movie>, allowedToFail = false) => {
     cy.log(`**updateMovie by id: ${id}**`)
-    return cy.api({
-      method: 'PUT',
-      url: `/movies/${id}`,
-      body: body,
-      retryOnStatusCodeFailure: !allowedToFail,
-      failOnStatusCode: !allowedToFail
-    })
+    return cy
+      .api({
+        method: 'PUT',
+        url: `/movies/${id}`,
+        body: body,
+        retryOnStatusCodeFailure: !allowedToFail,
+        failOnStatusCode: !allowedToFail
+      })
+      .its('body')
   }
 )
 
 Cypress.Commands.add('deleteMovie', (id: number, allowedToFail = false) => {
   cy.log('**deleteMovie by id: ${id}**')
-  return cy.api({
-    method: 'DELETE',
-    url: `/movies/${id}`,
-    retryOnStatusCodeFailure: !allowedToFail,
-    failOnStatusCode: !allowedToFail
-  })
+  return cy
+    .api({
+      method: 'DELETE',
+      url: `/movies/${id}`,
+      retryOnStatusCodeFailure: !allowedToFail,
+      failOnStatusCode: !allowedToFail
+    })
+    .its('body')
 })

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -1,1 +1,1 @@
-export * from './movie-types'
+export type * from './movie-types'

--- a/src/@types/schema.ts
+++ b/src/@types/schema.ts
@@ -31,7 +31,7 @@ export const CreateMovieResponseSchema = z
       .number()
       .int()
       .openapi({ example: 200, description: 'Response status code' }),
-    movie: z
+    data: z
       .object({
         id: z.number().openapi({ example: 1, description: 'Movie ID' }),
         name: z
@@ -58,16 +58,35 @@ export const ConflictMovieResponseSchema = z.object({
 })
 
 const movieObj = {
-  id: z.number(),
-  name: z.string(),
-  year: z.number()
+  id: z.number().openapi({ example: 1, description: 'Movie ID' }),
+  name: z.string().openapi({ example: 'Inception', description: 'Movie name' }),
+  year: z.number().openapi({ example: 2010, description: 'Release year' })
 }
+
 export const GetMovieResponseUnionSchema = z
-  .union([
-    // Use union to handle both single and array responses
-    z.object(movieObj).nullable(),
-    z.array(z.object(movieObj))
-  ])
+  .object({
+    status: z
+      .number()
+      .int()
+      .openapi({ example: 200, description: 'Response status code' }),
+    data: z.union([
+      z
+        .object(movieObj)
+        .nullable()
+        .openapi({
+          description: 'Movie details or null if not found',
+          example: { id: 1, name: 'Inception', year: 2010 }
+        }),
+      z.array(z.object(movieObj)).openapi({
+        description: 'List of movies or an empty array if no movies exist',
+        example: []
+      })
+    ]),
+    error: z.string().nullable().openapi({
+      description: 'Error message if an error occurred, otherwise null',
+      example: null
+    })
+  })
   .openapi('GetMovieResponse')
 
 export const MovieNotFoundResponseSchema = z.object({
@@ -117,7 +136,7 @@ export const UpdateMovieResponseSchema = z
       .number()
       .int()
       .openapi({ example: 200, description: 'Response status code' }),
-    movie: z
+    data: z
       .object({
         id: z.number().openapi({ example: 1, description: 'Movie ID' }),
         name: z

--- a/src/api-docs/openapi-generator.ts
+++ b/src/api-docs/openapi-generator.ts
@@ -189,7 +189,7 @@ export const openApiDoc = generator.generateDocument({
   openapi: '3.1.0',
   info: {
     title: 'Movies API',
-    version: '3.0.0',
+    version: '4.0.0',
     description: 'API for managing movies'
   },
   servers: [

--- a/src/api-docs/openapi.json
+++ b/src/api-docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Movies API",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "description": "API for managing movies"
   },
   "servers": [

--- a/src/api-docs/openapi.json
+++ b/src/api-docs/openapi.json
@@ -52,7 +52,7 @@
             "description": "Response status code",
             "example": 200
           },
-          "movie": {
+          "data": {
             "type": "object",
             "properties": {
               "id": {
@@ -85,55 +85,91 @@
         },
         "required": [
           "status",
-          "movie"
+          "data"
         ]
       },
       "GetMovieResponse": {
-        "anyOf": [
-          {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "number"
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "integer",
+            "description": "Response status code",
+            "example": 200
+          },
+          "data": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number",
+                    "description": "Movie ID",
+                    "example": 1
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Movie name",
+                    "example": "Inception"
+                  },
+                  "year": {
+                    "type": "number",
+                    "description": "Release year",
+                    "example": 2010
+                  }
+                },
+                "required": [
+                  "id",
+                  "name",
+                  "year"
+                ]
               },
-              "name": {
-                "type": "string"
+              {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number",
+                      "description": "Movie ID",
+                      "example": 1
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Movie name",
+                      "example": "Inception"
+                    },
+                    "year": {
+                      "type": "number",
+                      "description": "Release year",
+                      "example": 2010
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "year"
+                  ]
+                },
+                "description": "List of movies or an empty array if no movies exist",
+                "example": []
               },
-              "year": {
-                "type": "number"
+              {
+                "type": "null"
               }
-            },
-            "required": [
-              "id",
-              "name",
-              "year"
             ]
           },
-          {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "number"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "year": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "id",
-                "name",
-                "year"
-              ]
-            }
-          },
-          {
-            "type": "null"
+          "error": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Error message if an error occurred, otherwise null"
           }
+        },
+        "required": [
+          "status",
+          "data",
+          "error"
         ]
       },
       "MovieNotFound": {
@@ -201,7 +237,7 @@
             "description": "Response status code",
             "example": 200
           },
-          "movie": {
+          "data": {
             "type": "object",
             "properties": {
               "id": {
@@ -234,7 +270,7 @@
         },
         "required": [
           "status",
-          "movie"
+          "data"
         ]
       },
       "UpdateMovieRequest": {

--- a/src/api-docs/openapi.yml
+++ b/src/api-docs/openapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Movies API
-  version: 3.0.0
+  version: 4.0.0
   description: API for managing movies
 servers:
   - url: http://localhost:3000

--- a/src/api-docs/openapi.yml
+++ b/src/api-docs/openapi.yml
@@ -38,7 +38,7 @@ components:
           type: integer
           description: Response status code
           example: 200
-        movie:
+        data:
           type: object
           properties:
             id:
@@ -63,36 +63,66 @@ components:
           description: Error message, if any
       required:
         - status
-        - movie
+        - data
     GetMovieResponse:
-      anyOf:
-        - type: object
-          properties:
-            id:
-              type: number
-            name:
-              type: string
-            year:
-              type: number
-          required:
-            - id
-            - name
-            - year
-        - type: array
-          items:
-            type: object
-            properties:
-              id:
-                type: number
-              name:
-                type: string
-              year:
-                type: number
-            required:
-              - id
-              - name
-              - year
-        - type: "null"
+      type: object
+      properties:
+        status:
+          type: integer
+          description: Response status code
+          example: 200
+        data:
+          anyOf:
+            - type: object
+              properties:
+                id:
+                  type: number
+                  description: Movie ID
+                  example: 1
+                name:
+                  type: string
+                  description: Movie name
+                  example: Inception
+                year:
+                  type: number
+                  description: Release year
+                  example: 2010
+              required:
+                - id
+                - name
+                - year
+            - type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: number
+                    description: Movie ID
+                    example: 1
+                  name:
+                    type: string
+                    description: Movie name
+                    example: Inception
+                  year:
+                    type: number
+                    description: Release year
+                    example: 2010
+                required:
+                  - id
+                  - name
+                  - year
+              description: List of movies or an empty array if no movies exist
+              example: []
+            - type: "null"
+        error:
+          type:
+            - string
+            - "null"
+          description: Error message if an error occurred, otherwise null
+      required:
+        - status
+        - data
+        - error
     MovieNotFound:
       type: object
       properties:
@@ -142,7 +172,7 @@ components:
           type: integer
           description: Response status code
           example: 200
-        movie:
+        data:
           type: object
           properties:
             id:
@@ -167,7 +197,7 @@ components:
           description: Error message, if any
       required:
         - status
-        - movie
+        - data
     UpdateMovieRequest:
       type: object
       properties:

--- a/src/movie-adapter.test.ts
+++ b/src/movie-adapter.test.ts
@@ -52,9 +52,9 @@ describe('MovieAdapter', () => {
     it('should get all movies', async () => {
       prismaMock.movie.findMany.mockResolvedValue([mockMovie])
 
-      const result = await movieAdapter.getMovies()
+      const { data } = await movieAdapter.getMovies()
 
-      expect(result).toEqual([mockMovie])
+      expect(data).toEqual([mockMovie])
       expect(prismaMock.movie.findMany).toHaveBeenCalledTimes(1)
     })
 
@@ -64,7 +64,7 @@ describe('MovieAdapter', () => {
       )
 
       const result = await movieAdapter.getMovies()
-      expect(result).toEqual([]) // empty array on error
+      expect(result.data).toBe(null) // empty array on error
       expect(prismaMock.movie.findMany).toHaveBeenCalledTimes(1)
     })
   })
@@ -73,9 +73,10 @@ describe('MovieAdapter', () => {
     it('should get a movie by id', async () => {
       prismaMock.movie.findUnique.mockResolvedValue(mockMovie)
 
-      const result = await movieAdapter.getMovieById(mockMovie.id)
+      // @ts-expect-error TypeScript should chill for tests here
+      const { data } = await movieAdapter.getMovieById(mockMovie.id)
 
-      expect(result).toEqual(mockMovie)
+      expect(data).toEqual(mockMovie)
       expect(prismaMock.movie.findUnique).toHaveBeenCalledWith({
         where: { id: mockMovie.id }
       })
@@ -85,9 +86,10 @@ describe('MovieAdapter', () => {
       prismaMock.movie.findUnique.mockResolvedValue(null)
       const id = 999
 
-      const result = await movieAdapter.getMovieById(id)
+      // @ts-expect-error TypeScript should chill for tests here
+      const { data } = await movieAdapter.getMovieById(id)
 
-      expect(result).toBeNull()
+      expect(data).toBeNull()
       expect(prismaMock.movie.findUnique).toHaveBeenCalledWith({
         where: { id }
       })
@@ -98,9 +100,10 @@ describe('MovieAdapter', () => {
         new Error('Error fetching movie by id')
       )
 
-      const result = await movieAdapter.getMovieById(1)
+      // @ts-expect-error TypeScript should chill for tests here
+      const { data } = await movieAdapter.getMovieById(1)
 
-      expect(result).toBeNull() // Expect null on error
+      expect(data).toBeNull()
       expect(prismaMock.movie.findUnique).toHaveBeenCalledTimes(1)
     })
   })
@@ -109,9 +112,9 @@ describe('MovieAdapter', () => {
     it('should get a movie by name', async () => {
       prismaMock.movie.findFirst.mockResolvedValue(mockMovie)
 
-      const result = await movieAdapter.getMovieByName(mockMovie.name)
+      const { data } = await movieAdapter.getMovieByName(mockMovie.name)
 
-      expect(result).toEqual(mockMovie)
+      expect(data).toEqual(mockMovie)
       expect(prismaMock.movie.findFirst).toHaveBeenCalledWith({
         where: { name: mockMovie.name }
       })
@@ -121,9 +124,9 @@ describe('MovieAdapter', () => {
       prismaMock.movie.findFirst.mockResolvedValue(null)
       const name = 'Non-existent Movie'
 
-      const result = await movieAdapter.getMovieByName(name)
+      const { data } = await movieAdapter.getMovieByName(name)
 
-      expect(result).toBeNull()
+      expect(data).toBeNull()
       expect(prismaMock.movie.findFirst).toHaveBeenCalledWith({
         where: { name }
       })
@@ -134,9 +137,9 @@ describe('MovieAdapter', () => {
         new Error('Error fetching movie by name')
       )
 
-      const result = await movieAdapter.getMovieByName('Inception')
+      const { data } = await movieAdapter.getMovieByName('Inception')
 
-      expect(result).toBeNull() // Expect null on error
+      expect(data).toBeNull() // Expect null on error
       expect(prismaMock.movie.findFirst).toHaveBeenCalledTimes(1)
     })
   })
@@ -204,13 +207,10 @@ describe('MovieAdapter', () => {
       prismaMock.movie.create.mockResolvedValue({ id, ...movieData })
 
       const result = await movieAdapter.addMovie(movieData)
-
-      expect(result).toEqual(
-        expect.objectContaining({
-          status: 200,
-          movie: { id, ...movieData }
-        })
-      )
+      expect(result).toEqual({
+        status: 200,
+        data: { id, name: 'Inception', year: 2020 }
+      })
       expect(prismaMock.movie.create).toHaveBeenCalledWith({ data: movieData })
     })
 
@@ -223,7 +223,7 @@ describe('MovieAdapter', () => {
       expect(result).toEqual(
         expect.objectContaining({
           status: 200,
-          movie: { id, ...movieData }
+          data: { id, ...movieData }
         })
       )
       expect(prismaMock.movie.create).toHaveBeenCalledWith({
@@ -287,7 +287,7 @@ describe('MovieAdapter', () => {
       const result = await movieAdapter.updateMovie(updateMovieData, id)
       expect(result).toEqual({
         status: 200,
-        movie: updatedMovie
+        data: updatedMovie
       })
 
       expect(prismaMock.movie.findUnique).toHaveBeenCalledWith({

--- a/src/movie-adapter.ts
+++ b/src/movie-adapter.ts
@@ -67,13 +67,31 @@ export class MovieAdapter implements MovieRepository {
   }
 
   // Get all movies
-  async getMovies(): Promise<GetMovieResponse[]> {
+  async getMovies(): Promise<GetMovieResponse> {
     try {
       const movies = await this.prisma.movie.findMany()
-      return movies.length > 0 ? movies : []
+
+      if (movies.length > 0) {
+        return {
+          status: 200,
+          data: movies,
+          error: null
+        }
+      } else {
+        return {
+          status: 200,
+          data: [],
+          error: null
+        }
+      }
     } catch (error) {
       this.handleError(error)
-      return []
+
+      return {
+        status: 500,
+        data: null,
+        error: 'Failed to retrieve movies'
+      }
     }
   }
 
@@ -82,22 +100,55 @@ export class MovieAdapter implements MovieRepository {
     id: number
   ): Promise<GetMovieResponse | MovieNotFoundResponse> {
     try {
-      return await this.prisma.movie.findUnique({ where: { id } })
+      const movie = await this.prisma.movie.findUnique({ where: { id } })
+      if (movie) {
+        return {
+          status: 200,
+          data: movie, // return the movie object
+          error: null // no error if successful
+        }
+      }
+      return {
+        status: 404,
+        data: null, // return null if not found
+        error: `Movie with ID ${id} not found`
+      }
     } catch (error) {
       this.handleError(error)
-      return null
+      return {
+        status: 500,
+        data: null, // return null in case of failure
+        error: 'Internal server error'
+      }
     }
   }
 
   // Get a movie by its name
-  async getMovieByName(
-    name: string
-  ): Promise<GetMovieResponse | MovieNotFoundResponse> {
+  async getMovieByName(name: string): Promise<GetMovieResponse> {
     try {
-      return await this.prisma.movie.findFirst({ where: { name } })
+      const movie = await this.prisma.movie.findFirst({ where: { name } })
+
+      if (movie) {
+        return {
+          status: 200,
+          data: movie,
+          error: null
+        }
+      } else {
+        // Return a structured response if no movie is found
+        return {
+          status: 404,
+          data: null,
+          error: `Movie with name "${name}" not found`
+        }
+      }
     } catch (error) {
       this.handleError(error)
-      return null
+      return {
+        status: 500,
+        data: null,
+        error: 'Internal server error'
+      }
     }
   }
 
@@ -139,21 +190,27 @@ export class MovieAdapter implements MovieRepository {
       // Zod note: if you have a frontend, you can use the schema + safeParse there
       // in order to perform form validation before sending the data to the server
       const validationResult = validateSchema(CreateMovieSchema, data)
-      if (!validationResult.success)
+      if (!validationResult.success) {
         return { status: 400, error: validationResult.error }
+      }
 
-      const existingMovie = await this.getMovieByName(data.name)
+      // Check if the movie already exists
+      const existingMovie = await this.prisma.movie.findFirst({
+        where: { name: data.name }
+      })
+
       if (existingMovie) {
         return { status: 409, error: `Movie ${data.name} already exists` }
       }
 
+      // Create the new movie
       const movie = await this.prisma.movie.create({
         data: id ? { id, ...data } : data
       })
 
       return {
         status: 200,
-        movie
+        data: movie
       }
     } catch (error) {
       this.handleError(error)
@@ -188,7 +245,7 @@ export class MovieAdapter implements MovieRepository {
 
       return {
         status: 200,
-        movie: updatedMovie
+        data: updatedMovie
       }
     } catch (error) {
       this.handleError(error)

--- a/src/movie-repository.ts
+++ b/src/movie-repository.ts
@@ -14,7 +14,7 @@ import type {
 // It's a port in hexagonal architecture.
 
 export interface MovieRepository {
-  getMovies(): Promise<GetMovieResponse[]>
+  getMovies(): Promise<GetMovieResponse>
   getMovieById(id: number): Promise<GetMovieResponse | MovieNotFoundResponse>
   getMovieByName(
     name: string

--- a/src/movie-service.test.ts
+++ b/src/movie-service.test.ts
@@ -20,6 +20,13 @@ describe('MovieService', () => {
   let mockMovieRepository: jest.Mocked<MovieRepository>
   const id = 1
   const mockMovie: Movie = { id, name: 'Inception', year: 2020 }
+  const mockMovieResponse = { status: 200, data: mockMovie, error: null }
+  const mockMoviesResponse = {
+    status: 200,
+    data: [mockMovie],
+    error: null
+  }
+  const notFoundResponse = { status: 404, data: null, error: null }
 
   beforeEach(() => {
     mockMovieRepository = {
@@ -29,64 +36,68 @@ describe('MovieService', () => {
       deleteMovieById: jest.fn(),
       addMovie: jest.fn(),
       updateMovie: jest.fn()
-    }
+    } as jest.Mocked<MovieRepository>
 
     movieService = new MovieService(mockMovieRepository)
   })
 
   it('should get all movies', async () => {
-    mockMovieRepository.getMovies.mockResolvedValue([mockMovie])
+    mockMovieRepository.getMovies.mockResolvedValue(mockMoviesResponse)
 
-    const movies = await movieService.getMovies()
+    const { data } = await movieService.getMovies()
 
-    expect(movies).toEqual([mockMovie])
+    expect(data).toEqual([mockMovie])
     expect(mockMovieRepository.getMovies).toHaveBeenCalledTimes(1)
   })
 
   it('should get a movie by id', async () => {
-    mockMovieRepository.getMovieById.mockResolvedValue(mockMovie)
+    mockMovieRepository.getMovieById.mockResolvedValue(mockMovieResponse)
 
-    const result = await movieService.getMovieById(mockMovie.id)
+    // @ts-expect-error TypeScript should chill for tests here
+    const { data } = await movieService.getMovieById(mockMovie.id)
 
-    expect(result).toEqual(mockMovie)
+    expect(data).toEqual(mockMovie)
     expect(mockMovieRepository.getMovieById).toHaveBeenCalledWith(mockMovie.id)
   })
 
   it('should return null if movie by id not found', async () => {
-    mockMovieRepository.getMovieById.mockResolvedValue(null)
+    mockMovieRepository.getMovieById.mockResolvedValue(notFoundResponse)
     const id = 999
 
-    const result = await movieService.getMovieById(id)
+    // @ts-expect-error TypeScript should chill for tests here
+    const { data } = await movieService.getMovieById(id)
 
-    expect(result).toBeNull()
+    expect(data).toBeNull()
     expect(mockMovieRepository.getMovieById).toHaveBeenCalledWith(id)
   })
 
   it('should get a movie by name', async () => {
-    mockMovieRepository.getMovieByName.mockResolvedValue(mockMovie)
+    mockMovieRepository.getMovieByName.mockResolvedValue(mockMovieResponse)
 
-    const result = await movieService.getMovieByName(mockMovie.name)
+    // @ts-expect-error TypeScript should chill for tests here
+    const { data } = await movieService.getMovieByName(mockMovie.name)
 
-    expect(result).toEqual(mockMovie)
+    expect(data).toEqual(mockMovie)
     expect(mockMovieRepository.getMovieByName).toHaveBeenCalledWith(
       mockMovie.name
     )
   })
 
   it('should return null if movie by name not found', async () => {
-    mockMovieRepository.getMovieByName.mockResolvedValue(null)
+    mockMovieRepository.getMovieByName.mockResolvedValue(notFoundResponse)
     const name = 'Non-existent Movie'
 
-    const result = await movieService.getMovieByName(name)
+    // @ts-expect-error TypeScript should chill for tests here
+    const { data } = await movieService.getMovieByName(name)
 
-    expect(result).toBeNull()
+    expect(data).toBeNull()
     expect(mockMovieRepository.getMovieByName).toHaveBeenCalledWith(name)
   })
 
   it('should add a new movie', async () => {
     const expectedResult = {
       status: 200,
-      movie: mockMovie,
+      data: mockMovie,
       error: undefined
     }
     mockMovieRepository.addMovie.mockResolvedValue(expectedResult)
@@ -103,7 +114,7 @@ describe('MovieService', () => {
   it('should update a movie', async () => {
     const expectedResult = {
       status: 200,
-      movie: mockMovie,
+      data: mockMovie,
       error: undefined
     }
     mockMovieRepository.updateMovie.mockResolvedValue(expectedResult)

--- a/src/movie-service.ts
+++ b/src/movie-service.ts
@@ -20,7 +20,7 @@ export class MovieService {
     this.movieRepository = movieRepository
   }
 
-  async getMovies(): Promise<GetMovieResponse[]> {
+  async getMovies(): Promise<GetMovieResponse> {
     return this.movieRepository.getMovies()
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,9 @@ import type {
   UpdateMovieResponse,
   CreateMovieResponse,
   MovieNotFoundResponse,
-  ConflictMovieResponse
+  ConflictMovieResponse,
+  GetMovieResponse,
+  DeleteMovieResponse
 } from './@types'
 
 // Initialize Express server
@@ -27,21 +29,38 @@ const movieAdapter = new MovieAdapter(prisma)
 const movieService = new MovieService(movieAdapter)
 
 type MovieResponse =
+  | DeleteMovieResponse
+  | GetMovieResponse
   | UpdateMovieResponse
   | CreateMovieResponse
   | MovieNotFoundResponse
   | ConflictMovieResponse
 
-function handleMovieResponse(res: Response, result: MovieResponse): Response {
-  if ('error' in result) {
+function handleResponse(res: Response, result: MovieResponse): Response {
+  if ('error' in result && result.error) {
     return res.status(result.status).json({ error: result.error })
-  } else if ('movie' in result) {
+  } else if ('data' in result) {
+    if (result.data === null) {
+      return res.status(404).json({ error: 'No movies found' })
+    }
     return res
       .status(result.status)
-      .json({ status: result.status, movie: result.movie })
+      .json({ status: result.status, data: result.data })
+  } else if ('message' in result) {
+    // Handle delete movie case with a success message
+    return res
+      .status(result.status)
+      .json({ status: result.status, message: result.message })
   } else {
     return res.status(500).json({ error: 'Unexpected error occurred' })
   }
+}
+
+function validateId(res: Response, id: number): boolean | Response {
+  if (isNaN(id)) {
+    res.status(400).json({ error: 'Invalid movie ID provided' })
+    return false // prevent further execution
+  } else return true // id is valid
 }
 
 // Routes are focused on handling HTTP requests and responses,
@@ -56,57 +75,44 @@ server.get('/movies', async (req, res) => {
 
   if (typeof name === 'string') {
     const movie = await movieService.getMovieByName(name as string)
-    if (!movie) {
-      return res
-        .status(404)
-        .json({ error: `Movie with name "${name}" not found` })
-    } else {
-      return res.json(movie)
-    }
+    console.log({ movie })
+    return handleResponse(res, movie)
   } else if (name) {
     return res.status(400).json({ error: 'Invalid movie name provided' })
   } else {
     const allMovies = await movieService.getMovies()
-    return res.json(allMovies)
+    return handleResponse(res, allMovies)
   }
 })
 
 server.get('/movies/:id', async (req, res) => {
-  const movie = await movieService.getMovieById(parseInt(req.params.id!))
+  const movieId = parseInt(req.params.id!)
+  validateId(res, movieId)
 
-  if (!movie) return res.status(404).json({ error: 'Movie not found' })
-  else return res.json(movie)
+  const movie = await movieService.getMovieById(movieId)
+  return handleResponse(res, movie)
 })
 
 server.post('/movies', async (req, res) => {
   const result = await movieService.addMovie(req.body)
 
-  return handleMovieResponse(res, result)
+  return handleResponse(res, result)
 })
 
 server.put('/movies/:id', async (req, res) => {
   const movieId = parseInt(req.params.id!)
   const result = await movieService.updateMovie(req.body, movieId)
 
-  return handleMovieResponse(res, result)
+  return handleResponse(res, result)
 })
 
 server.delete('/movies/:id', async (req, res) => {
-  const { status } = await movieService.deleteMovieById(
-    parseInt(req.params.id!)
-  )
+  const movieId = parseInt(req.params.id!)
+  validateId(res, movieId)
 
-  if (status === 404) {
-    return res.status(404).json({
-      error: `Movie ${req.params.id} not found`,
-      status: status
-    })
-  } else {
-    return res.status(200).json({
-      message: `Movie ${req.params.id} has been deleted`,
-      status: status
-    })
-  }
+  const result = await movieService.deleteMovieById(movieId)
+
+  return handleResponse(res, result)
 })
 
 export { server }

--- a/src/server.ts
+++ b/src/server.ts
@@ -75,7 +75,6 @@ server.get('/movies', async (req, res) => {
 
   if (typeof name === 'string') {
     const movie = await movieService.getMovieByName(name as string)
-    console.log({ movie })
     return handleResponse(res, movie)
   } else if (name) {
     return res.status(400).json({ error: 'Invalid movie name provided' })

--- a/test.http
+++ b/test.http
@@ -68,4 +68,4 @@ GET {{baseUrl}}/movies/999
 
 ###
 # @name deleteNonExistentMovie
-DELETE {{baseUrl}}/movies/999
+DELETE {{baseUrl}}/movies/4


### PR DESCRIPTION
* Updated the schema so that GetMovie responses (getAll & getByName) match the schema of the rest of the features; status, data, error are now consistently returned
* Updated the adapter to adhere to the schema returning status, data, error objects.
* Updated cy commands and types, now they yield the body 
* Updated e2e, moved schema checks after the verifications

### Pact Breaking Change?

- [x] Pact breaking change (check if this PR introduces a breaking change, which relaxes Pact verification to only run vs the matching branch of the consumer).
