### PR TITLE
experiment: new get response bi

### DIFF
--- a/cypress/e2e/crud-movie.cy.ts
+++ b/cypress/e2e/crud-movie.cy.ts
@@ -112,7 +112,7 @@ describe('CRUD movie', () => {
           .should(
             spok({
               status: 404,
-              message: spok.string
+              error: spok.string
             })
           )
           .validateSchema(schema, {

--- a/src/movie-adapter.test.ts
+++ b/src/movie-adapter.test.ts
@@ -173,7 +173,7 @@ describe('MovieAdapter', () => {
 
       const expectedResult = {
         status: 404,
-        message: `Movie with ID ${id} not found`
+        error: `Movie with ID ${id} not found`
       }
       expect(result).toStrictEqual(expectedResult)
       expect(prismaMock.movie.delete).toHaveBeenCalledWith({ where: { id } })

--- a/src/movie-adapter.ts
+++ b/src/movie-adapter.ts
@@ -172,7 +172,7 @@ export class MovieAdapter implements MovieRepository {
       ) {
         return {
           status: 404,
-          message: `Movie with ID ${id} not found`
+          error: `Movie with ID ${id} not found`
         }
       }
       this.handleError(error)

--- a/src/server.ts
+++ b/src/server.ts
@@ -38,10 +38,14 @@ type MovieResponse =
 
 function handleResponse(res: Response, result: MovieResponse): Response {
   if ('error' in result && result.error) {
-    return res.status(result.status).json({ error: result.error })
+    return res
+      .status(result.status)
+      .json({ status: result.status, error: result.error })
   } else if ('data' in result) {
     if (result.data === null) {
-      return res.status(404).json({ error: 'No movies found' })
+      return res
+        .status(result.status)
+        .json({ status: result.status, error: 'No movies found' })
     }
     return res
       .status(result.status)


### PR DESCRIPTION
*Better types in the tests.

*`a request to delete a non-existing movie` now returns a MovieNotFoundResponse, with `{status, error}` instead of `{status, message}`

### Pact Breaking Change?

- [x] Pact breaking change (check if this PR introduces a breaking change, which relaxes Pact verification to only run vs the matching branch of the consumer).
