### PR TITLE
feat: auth

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+src/api-docs/openapi.json

--- a/cypress/index.d.ts
+++ b/cypress/index.d.ts
@@ -17,27 +17,32 @@ declare global {
     interface Chainable<Subject> {
       /** Gets a list of movies
        * ```js
-       * cy.getAllMovies()
+       * cy.getAllMovies(token)
        * ```
        */
-      getAllMovies(allowedToFail?: boolean): Chainable<GetMovieResponse>
+      getAllMovies(
+        token: string,
+        allowedToFail?: boolean
+      ): Chainable<GetMovieResponse>
 
       /** Gets a movie by id
        * ```js
-       * cy.getMovieById(1)
+       * cy.getMovieById(token, 1)
        * ```
        */
       getMovieById(
+        token: string,
         id: number,
         allowedToFail?: boolean
       ): Chainable<GetMovieResponse>
 
       /** Gets a movie by name
        * ```js
-       * cy.getMovieByName('The Great Gatsby')
+       * cy.getMovieByName(token, 'The Great Gatsby')
        * ```
        */
       getMovieByName(
+        token: string,
         name: string,
         allowedToFail?: boolean
       ): Chainable<GetMovieResponse>
@@ -48,6 +53,7 @@ declare global {
        * ```
        */
       addMovie(
+        token: string,
         body: Omit<Movie, 'id'>,
         allowedToFail?: boolean
       ): Chainable<CreateMovieResponse>
@@ -58,6 +64,7 @@ declare global {
        * ```
        */
       updateMovie(
+        token: string,
         id: number,
         body: Partial<Movie>
       ): Chainable<UpdateMovieResponse>
@@ -68,6 +75,7 @@ declare global {
        * ```
        */
       deleteMovie(
+        token: string,
         id: number,
         allowedToFail?: boolean
       ): Chainable<DeleteMovieResponse>
@@ -105,6 +113,12 @@ declare global {
           status?: string | number
         }
       ): Chainable<Subject>
+
+      /**
+       * If the token exists, reuses it
+       * If no token is exists, gets a token
+       */
+      maybeGetToken(sessionName: string): Chainable<string>
     }
   }
 }

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,26 +1,20 @@
 import './commands'
+import './get-token'
 import 'cypress-map'
 import '@bahmutov/cy-api'
 import type { Movie } from '@prisma/client'
 
-Cypress.Commands.add('getAllMovies', (allowedToFail = false) => {
+const commonHeaders = (token: string) => ({
+  Authorization: token
+})
+
+Cypress.Commands.add('getAllMovies', (token: string, allowedToFail = false) => {
   cy.log('**getAllMovies**')
   return cy
     .api({
       method: 'GET',
       url: '/movies',
-      retryOnStatusCodeFailure: !allowedToFail,
-      failOnStatusCode: !allowedToFail
-    })
-    .its('body')
-})
-
-Cypress.Commands.add('getMovieById', (id: number, allowedToFail = false) => {
-  cy.log(`**getMovieById: ${id}**`)
-  return cy
-    .api({
-      method: 'GET',
-      url: `/movies/${id}`,
+      headers: commonHeaders(token),
       retryOnStatusCodeFailure: !allowedToFail,
       failOnStatusCode: !allowedToFail
     })
@@ -28,14 +22,31 @@ Cypress.Commands.add('getMovieById', (id: number, allowedToFail = false) => {
 })
 
 Cypress.Commands.add(
+  'getMovieById',
+  (token: string, id: number, allowedToFail = false) => {
+    cy.log(`**getMovieById: ${id}**`)
+    return cy
+      .api({
+        method: 'GET',
+        url: `/movies/${id}`,
+        headers: commonHeaders(token),
+        retryOnStatusCodeFailure: !allowedToFail,
+        failOnStatusCode: !allowedToFail
+      })
+      .its('body')
+  }
+)
+
+Cypress.Commands.add(
   'getMovieByName',
-  (name: string, allowedToFail = false) => {
+  (token: string, name: string, allowedToFail = false) => {
     cy.log(`**getMovieByName: ${name}**`)
     return cy
       .api({
         method: 'GET',
         url: '/movies',
         qs: { name },
+        headers: commonHeaders(token),
         retryOnStatusCodeFailure: !allowedToFail,
         failOnStatusCode: !allowedToFail
       })
@@ -45,13 +56,14 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   'addMovie',
-  (body: Omit<Movie, 'id'>, allowedToFail = false) => {
+  (token: string, body: Omit<Movie, 'id'>, allowedToFail = false) => {
     cy.log('**addMovie**')
     return cy
       .api({
         method: 'POST',
         url: '/movies',
         body: body,
+        headers: commonHeaders(token),
         retryOnStatusCodeFailure: !allowedToFail,
         failOnStatusCode: !allowedToFail
       })
@@ -62,13 +74,14 @@ Cypress.Commands.add(
 // update movie
 Cypress.Commands.add(
   'updateMovie',
-  (id: number, body: Partial<Movie>, allowedToFail = false) => {
+  (token: string, id: number, body: Partial<Movie>, allowedToFail = false) => {
     cy.log(`**updateMovie by id: ${id}**`)
     return cy
       .api({
         method: 'PUT',
         url: `/movies/${id}`,
         body: body,
+        headers: commonHeaders(token),
         retryOnStatusCodeFailure: !allowedToFail,
         failOnStatusCode: !allowedToFail
       })
@@ -76,14 +89,18 @@ Cypress.Commands.add(
   }
 )
 
-Cypress.Commands.add('deleteMovie', (id: number, allowedToFail = false) => {
-  cy.log('**deleteMovie by id: ${id}**')
-  return cy
-    .api({
-      method: 'DELETE',
-      url: `/movies/${id}`,
-      retryOnStatusCodeFailure: !allowedToFail,
-      failOnStatusCode: !allowedToFail
-    })
-    .its('body')
-})
+Cypress.Commands.add(
+  'deleteMovie',
+  (token: string, id: number, allowedToFail = false) => {
+    cy.log('**deleteMovie by id: ${id}**')
+    return cy
+      .api({
+        method: 'DELETE',
+        url: `/movies/${id}`,
+        headers: commonHeaders(token),
+        retryOnStatusCodeFailure: !allowedToFail,
+        failOnStatusCode: !allowedToFail
+      })
+      .its('body')
+  }
+)

--- a/cypress/support/get-token.ts
+++ b/cypress/support/get-token.ts
@@ -1,0 +1,15 @@
+import 'cypress-data-session'
+const getToken = () =>
+  cy.api({ method: 'POST', url: '/auth/fake-token' }).its('body.token')
+
+const maybeGetToken = (sessionName: string) =>
+  cy.dataSession({
+    name: sessionName,
+
+    validate: () => true,
+
+    setup: () => getToken(),
+
+    shareAcrossSpecs: true
+  })
+Cypress.Commands.add('maybeGetToken', maybeGetToken)

--- a/cypress/support/plugins.ts
+++ b/cypress/support/plugins.ts
@@ -1,4 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const cyDataSession = require('cypress-data-session/src/plugin')
 
 /**

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -26,10 +26,10 @@ export const config: JestConfigWithTsJest = {
   ],
   coverageThreshold: {
     global: {
-      statements: 50,
-      branches: 50,
-      lines: 50,
-      functions: 50
+      statements: 40,
+      branches: 40,
+      lines: 40,
+      functions: 40
     }
   },
   moduleDirectories: ['node_modules', 'src'],

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "reset:db": "tsx ./scripts/global-setup.ts",
     "start": "npm run db:migrate && npm run reset:db && nodemon",
     "prettier": "prettier --ignore-path .gitignore \"**/*.+(js|ts|json)\"",
-    "fix:format": "npm run prettier -- --write",
+    "fix:format": "prettier --write '**/*.{js,ts,json}' --ignore-path .prettierignore",
     "validate": "npm-run-all --parallel typecheck lint fix:format test",
     "test": "jest --detectOpenHandles --verbose --silent --config jest.config.ts",
     "test:watch": "jest --watch --config jest.config.ts",

--- a/src/middleware/auth-middleware.ts
+++ b/src/middleware/auth-middleware.ts
@@ -1,0 +1,36 @@
+import type { Request, Response, NextFunction } from 'express'
+
+// define a type for the token's structure, which contains the issuedAt date.
+type Token = {
+  issuedAt: Date // the token contains a precise Date object
+}
+
+// Function to check if the token's timestamp is within 1 hour
+const isValidAuthTimeStamp = (token: Token) => {
+  const tokenTime = token.issuedAt.getTime() // get time in milliseconds
+  const currentTime = new Date().getTime() // current time in milliseconds
+  const diff = (currentTime - tokenTime) / 1000 // difference in seconds
+
+  return diff >= 0 && diff <= 3600 // Token valid for 1 hour
+}
+export function authMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const authHeader = req.headers.authorization
+  if (!authHeader)
+    return res
+      .status(401)
+      .json({ error: 'Unauthorized; no Authorization header.', status: 401 })
+
+  const tokenStr = authHeader.replace('Bearer ', '')
+  const token: Token = { issuedAt: new Date(tokenStr) }
+
+  if (!isValidAuthTimeStamp(token))
+    return res
+      .status(401)
+      .json({ error: 'Unauthorized; not valid timestamp.', status: 401 })
+
+  next() // proceed if valid
+}

--- a/src/provider-contract.pacttest.ts
+++ b/src/provider-contract.pacttest.ts
@@ -2,6 +2,7 @@ import { Verifier } from '@pact-foundation/pact'
 import { stateHandlers } from './test-helpers/state-handlers'
 import { buildVerifierOptions } from './test-helpers/pact-utils'
 import { truncateTables } from '../scripts/truncate-tables'
+import { requestFilter } from './test-helpers/pact-request-filter'
 
 // 1) Run the provider service
 // 2) Setup the provider verifier options
@@ -21,6 +22,7 @@ describe('Pact Verification', () => {
     enablePending: PACT_ENABLE_PENDING === 'true',
     port,
     stateHandlers,
+    requestFilter,
     beforeEach: async () => {
       // console.log('I run before each test coming from the consumer...')
       await truncateTables()

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,0 +1,61 @@
+import { PrismaClient } from '@prisma/client'
+import { Router } from 'express'
+import type {
+  CreateMovieResponse,
+  DeleteMovieResponse,
+  GetMovieResponse,
+  UpdateMovieResponse
+} from './@types'
+import { authMiddleware } from './middleware/auth-middleware'
+import { validateId } from './middleware/validate-movie-id'
+import { MovieAdapter } from './movie-adapter'
+import { MovieService } from './movie-service'
+import { formatResponse } from './utils/format-response'
+
+export const moviesRoute = Router()
+
+// apply auth middleware to all routes under this prefix
+moviesRoute.use(authMiddleware)
+
+// Initialize PrismaClient
+const prisma = new PrismaClient()
+// Create the MovieAdapter and inject it into MovieService
+const movieAdapter = new MovieAdapter(prisma)
+const movieService = new MovieService(movieAdapter)
+
+// Routes are focused on handling HTTP requests and responses,
+// delegating business logic to the Movies class (Separation of Concerns)
+
+moviesRoute.get('/', async (req, res) => {
+  const name = req.query.name
+
+  if (typeof name === 'string') {
+    const movie = await movieService.getMovieByName(name as string)
+    return formatResponse(res, movie as GetMovieResponse)
+  } else if (name) {
+    return res.status(400).json({ error: 'Invalid movie name provided' })
+  } else {
+    const allMovies = await movieService.getMovies()
+    return formatResponse(res, allMovies as GetMovieResponse)
+  }
+})
+
+moviesRoute.post('/', async (req, res) => {
+  const result = await movieService.addMovie(req.body)
+  return formatResponse(res, result as CreateMovieResponse)
+})
+
+moviesRoute.get('/:id', validateId, async (req, res) => {
+  const result = await movieService.getMovieById(Number(req.params.id))
+  return formatResponse(res, result as GetMovieResponse)
+})
+
+moviesRoute.put('/:id', validateId, async (req, res) => {
+  const result = await movieService.updateMovie(req.body, Number(req.params.id))
+  return formatResponse(res, result as UpdateMovieResponse)
+})
+
+moviesRoute.delete('/:id', validateId, async (req, res) => {
+  const result = await movieService.deleteMovieById(Number(req.params.id))
+  return formatResponse(res, result as DeleteMovieResponse)
+})

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,16 +1,6 @@
-import { PrismaClient } from '@prisma/client'
 import cors from 'cors'
 import express, { json } from 'express'
-import { validateId } from './middleware/validate-movie-id'
-import { MovieAdapter } from './movie-adapter'
-import { MovieService } from './movie-service'
-import { formatResponse } from './utils/format-response'
-import type {
-  CreateMovieResponse,
-  DeleteMovieResponse,
-  GetMovieResponse,
-  UpdateMovieResponse
-} from './@types'
+import { moviesRoute } from './routes'
 
 // Initialize Express server
 const server = express()
@@ -21,54 +11,15 @@ server.use(
 )
 server.use(json())
 
-// Initialize PrismaClient
-const prisma = new PrismaClient()
-// Create the MovieAdapter and inject it into MovieService
-const movieAdapter = new MovieAdapter(prisma)
-const movieService = new MovieService(movieAdapter)
-
-// Routes are focused on handling HTTP requests and responses,
-// delegating business logic to the Movies class (Separation of Concerns)
-
 server.get('/', (_, res) =>
   res.status(200).json({ message: 'Server is running' })
 )
 
-server.get('/movies', async (req, res) => {
-  const name = req.query.name
+server.use('/movies', moviesRoute)
 
-  if (typeof name === 'string') {
-    const movie = await movieService.getMovieByName(name as string)
-    return formatResponse(res, movie as GetMovieResponse)
-  } else if (name) {
-    return res.status(400).json({ error: 'Invalid movie name provided' })
-  } else {
-    const allMovies = await movieService.getMovies()
-    return formatResponse(res, allMovies as GetMovieResponse)
-  }
-})
-
-server.get('/movies/:id', validateId, async (req, res) => {
-  const result = await movieService.getMovieById(Number(req.params.id))
-  return formatResponse(res, result as GetMovieResponse)
-})
-
-server.post('/movies', async (req, res) => {
-  const result = await movieService.addMovie(req.body)
-
-  return formatResponse(res, result as CreateMovieResponse)
-})
-
-server.put('/movies/:id', validateId, async (req, res) => {
-  const result = await movieService.updateMovie(req.body, Number(req.params.id))
-
-  return formatResponse(res, result as UpdateMovieResponse)
-})
-
-server.delete('/movies/:id', validateId, async (req, res) => {
-  const result = await movieService.deleteMovieById(Number(req.params.id))
-
-  return formatResponse(res, result as DeleteMovieResponse)
+server.use('/auth/fake-token', (_, res) => {
+  const token = `Bearer ${new Date().toISOString()}`
+  return res.status(200).json({ token, status: 200 })
 })
 
 export { server }

--- a/src/test-helpers/pact-request-filter.ts
+++ b/src/test-helpers/pact-request-filter.ts
@@ -35,7 +35,7 @@ const handleExpressEnv = (
 /**
  * Creates a request filter function that adds an Authorization header if not present.
  * The function is designed as a higher-order function to allow for customization of token generation
- * and also to fulfill Pact's type requirements of handling three arguments: `req`, `res`, and `next`.
+ * and also to fulfill Pact's express-like type requirements of handling three arguments : `req`, `res`, and `next`.
  *
  * @param {RequestFilterOptions} [options] - Options to customize the token generation logic.
  * @returns {ProxyOptions['requestFilter']} - A request filter that adds Authorization header. */
@@ -49,8 +49,6 @@ const createRequestFilter =
     if (!req.headers['Authorization']) {
       req.headers['Authorization'] = `Bearer ${tokenGenerator()}`
     }
-
-    console.log('Modified headers:', req.headers)
 
     return handleExpressEnv(req, next)
   }

--- a/src/test-helpers/pact-request-filter.ts
+++ b/src/test-helpers/pact-request-filter.ts
@@ -1,0 +1,66 @@
+import type { ProxyOptions } from '@pact-foundation/pact/src/dsl/verifier/proxy/types'
+
+// generic HttpRequest structure to accommodate both Express and non-Express environments
+type HttpRequest = {
+  headers: Record<string, string | string[] | undefined>
+  body?: unknown
+}
+
+type NextFunction = () => void | undefined
+
+// allows customization of token generation logic
+type RequestFilterOptions = {
+  tokenGenerator?: () => string
+}
+
+/**
+ * Handles environments with and without Express-like `next()` middleware.
+ * If `next()` is present, it will call it; otherwise, it returns the modified request.
+ * @param {HttpRequest} req - The incoming HTTP request object.
+ * @param {NextFunction} next - The Express-style `next()` function, if available.
+ * @returns {HttpRequest | undefined} - The modified request or undefined if `next()` was called. */
+const handleExpressEnv = (
+  req: HttpRequest,
+  next: NextFunction
+): HttpRequest | undefined => {
+  // If this is an Express environment, call next()
+  if (next && typeof next === 'function') {
+    next()
+  } else {
+    // In a non-Express environment, return the modified request
+    return req
+  }
+}
+
+/**
+ * Creates a request filter function that adds an Authorization header if not present.
+ * The function is designed as a higher-order function to allow for customization of token generation
+ * and also to fulfill Pact's type requirements of handling three arguments: `req`, `res`, and `next`.
+ *
+ * @param {RequestFilterOptions} [options] - Options to customize the token generation logic.
+ * @returns {ProxyOptions['requestFilter']} - A request filter that adds Authorization header. */
+const createRequestFilter =
+  (options?: RequestFilterOptions): ProxyOptions['requestFilter'] =>
+  (req, _, next) => {
+    const defaultTokenGenerator = () => new Date().toISOString()
+    const tokenGenerator = options?.tokenGenerator || defaultTokenGenerator
+
+    // add an authorization header if not present
+    if (!req.headers['Authorization']) {
+      req.headers['Authorization'] = `Bearer ${tokenGenerator()}`
+    }
+
+    console.log('Modified headers:', req.headers)
+
+    return handleExpressEnv(req, next)
+  }
+
+// if you have a token generator, pass it as an option
+// createRequestFilter({ tokenGenerator: myCustomTokenGenerator })
+export const requestFilter = createRequestFilter()
+
+export const noOpRequestFilter: ProxyOptions['requestFilter'] = (
+  req,
+  _,
+  next
+) => handleExpressEnv(req, next)

--- a/src/test-helpers/pact-utils.ts
+++ b/src/test-helpers/pact-utils.ts
@@ -105,10 +105,12 @@ export function buildVerifierOptions({
     'Provider Version Branch': providerVersionBranch,
     'Pact Broker URL': pactBrokerUrl,
     'Pact Payload URL': pactPayloadUrl || 'Not Provided',
-    'Enable Pending': enablePending
+    'Enable Pending': enablePending,
+    'Request Filter':
+      requestFilter === noOpRequestFilter
+        ? 'Default (No-Op)'
+        : 'Custom Provided'
   })
-
-  console.log('Request filter being passed to Verifier:', requestFilter)
 
   const options: VerifierOptions = {
     provider,
@@ -124,8 +126,6 @@ export function buildVerifierOptions({
     providerVersionBranch,
     enablePending // use this if breaking changes from a consumer somehow got in main, and the provider cannot release (allow blasphemy!)
   }
-
-  console.log('Verifier options:', options)
 
   // When the CI triggers the provider tests, we need to use the PACT_PAYLOAD_URL
   // To use the PACT_PAYLOAD_URL, we need to update the provider options to use this URL instead.

--- a/test.http
+++ b/test.http
@@ -1,35 +1,50 @@
 @baseUrl = http://localhost:3001
 
 ###
+# @name generateToken
+# Simulate token generation (mocked)
+GET {{baseUrl}}/auth/fake-token
+
+@token =  {{generateToken.response.body.token}}
+
+###
 # @name heartbeat
 GET {{baseUrl}}
-
-###
-# @name getAllMovies
-GET {{baseUrl}}/movies
-
-###
-# @name getMovieById
-GET {{baseUrl}}/movies/1
-
-###
-# @name getMovieByName
-GET {{baseUrl}}/movies?name=Inception
 
 ###
 # @name addMovie
 POST {{baseUrl}}/movies
 Content-Type: application/json
+Authorization: {{token}}
 
 {
-    "name": "Inception",
+    "name": "Inception 2",
     "year": 2010
 }
+
+@movieId = {{addMovie.response.body.data.id}}
+@movieName = {{addMovie.response.body.data.name}}
+
+###
+# @name getAllMovies
+GET {{baseUrl}}/movies
+Authorization: {{token}}
+
+###
+# @name getMovieById
+GET {{baseUrl}}/movies/{{movieId}}
+Authorization: {{token}}
+
+###
+# @name getMovieByName
+GET {{baseUrl}}/movies?name={{movieName}}
+Authorization: {{token}}
 
 ###
 # @name addDuplicateMovie
 POST {{baseUrl}}/movies/
 Content-Type: application/json
+Authorization: {{token}}
 
 {
     "name": "Inception",
@@ -40,6 +55,7 @@ Content-Type: application/json
 # @name addMovieInvalidYear
 POST {{baseUrl}}/movies
 Content-Type: application/json
+Authorization: {{token}}
 
 {
     "name": "Invalid Year Movie",
@@ -48,24 +64,27 @@ Content-Type: application/json
 
 ###
 # @name updateMovie
-PUT {{baseUrl}}/movies/1
+PUT {{baseUrl}}/movies/{{movieId}}
 Content-Type: application/json
+Authorization: {{token}}
 
 {
     "name": "Inception Updated",
     "year": 2015
 }
 
-
 ###
 # @name deleteMovie
-DELETE {{baseUrl}}/movies/1
+DELETE {{baseUrl}}/movies/{{movieId}}
+Authorization: {{token}}
 
 ###
 # @name getNonExistentMovie
 GET {{baseUrl}}/movies/999
+Authorization: {{token}}
 
 
 ###
 # @name deleteNonExistentMovie
 DELETE {{baseUrl}}/movies/999
+Authorization: {{token}}


### PR DESCRIPTION
* Added authentication to the routes

* Used express routes to refactor the routes with auth

* Used auth-middleware

* `pact-request-filter.ts` helper: a generic, customizable helper for any environment

* Modified the test.http and cy api e2e to use the token

* Data-session for cy with token usage

* Prettier shouldn't format openapi.json

  
### Pact Breaking Change?

- [ ] Pact breaking change (check if this PR introduces a breaking change, which relaxes Pact verification to only run vs the matching branch of the consumer).
