### PR TITLE
fix: specify the consumer

### DIFF
--- a/src/provider-contract.pacttest.ts
+++ b/src/provider-contract.pacttest.ts
@@ -17,10 +17,10 @@ describe('Pact Verification', () => {
   const port = process.env.PORT || '3001'
   const options = buildVerifierOptions({
     provider: 'MoviesAPI',
-    consumer: process.env.PACT_CONSUMER, // filter by the consumer, or run for all if no env var is provided
+    consumer: 'WebConsumer', // with multiple pact test files, best to specify the consumer
     includeMainAndDeployed: PACT_BREAKING_CHANGE !== 'true', // if it is a breaking change, set the env var
     enablePending: PACT_ENABLE_PENDING === 'true',
-    logLevel: 'debug',
+    // logLevel: 'debug',
     port,
     stateHandlers,
     requestFilter,

--- a/src/provider-kafka.pacttest.ts
+++ b/src/provider-kafka.pacttest.ts
@@ -13,10 +13,10 @@ const GITHUB_BRANCH = process.env.GITHUB_BRANCH || 'local'
 describe('Pact Verification', () => {
   const options = buildMessageProviderPact({
     provider: 'MoviesAPI-event-producer', // ensure unique provider name for message pacts
-    consumer: process.env.PACT_CONSUMER, // optional: Specify if targeting a specific consumer
+    consumer: 'MoviesAPI-event-producer', // with multiple pact test files, best to specify the consumer
     includeMainAndDeployed: PACT_BREAKING_CHANGE !== 'true', // if it is a breaking change, set the env var
     enablePending: PACT_ENABLE_PENDING === 'true',
-    logLevel: 'debug',
+    // logLevel: 'debug',
     messageProviders // the bread and butter of the test is here
   })
   const provider = new MessageProviderPact(options)

--- a/src/provider-kafka.pacttest.ts
+++ b/src/provider-kafka.pacttest.ts
@@ -13,7 +13,7 @@ const GITHUB_BRANCH = process.env.GITHUB_BRANCH || 'local'
 describe('Pact Verification', () => {
   const options = buildMessageProviderPact({
     provider: 'MoviesAPI-event-producer', // ensure unique provider name for message pacts
-    consumer: 'MoviesAPI-event-producer', // with multiple pact test files, best to specify the consumer
+    consumer: 'WebConsumer-event-consumer', // with multiple pact test files, best to specify the consumer
     includeMainAndDeployed: PACT_BREAKING_CHANGE !== 'true', // if it is a breaking change, set the env var
     enablePending: PACT_ENABLE_PENDING === 'true',
     // logLevel: 'debug',


### PR DESCRIPTION
Specify consumers distincly to avoid issues with webhook triggered tests.

### Pact Breaking Change?

- [ ] Pact breaking change (check if this PR introduces a breaking change, which relaxes Pact verification to only run vs the matching branch of the consumer).
