### PR TITLE
fix: newer buildConsumerVersionSelectors and buildVerifierOptions

### DIFF
--- a/src/test-helpers/pact-utils/build-verifier-options.ts
+++ b/src/test-helpers/pact-utils/build-verifier-options.ts
@@ -73,7 +73,7 @@ export function buildVerifierOptions({
   publishVerificationResult = true,
   pactBrokerToken = process.env.PACT_BROKER_TOKEN,
   providerVersion = process.env.GITHUB_SHA,
-  providerVersionBranch = process.env.GITHUB_BRANCH,
+  providerVersionBranch = process.env.GITHUB_BRANCH || 'main', // default to main if provider branch is not set
   pactBrokerUrl = process.env.PACT_BROKER_BASE_URL,
   pactPayloadUrl = process.env.PACT_PAYLOAD_URL
 }: {
@@ -181,7 +181,7 @@ export function buildMessageVerifierOptions({
   publishVerificationResult = true,
   pactBrokerToken = process.env.PACT_BROKER_TOKEN,
   providerVersion = process.env.GITHUB_SHA,
-  providerVersionBranch = process.env.GITHUB_BRANCH,
+  providerVersionBranch = process.env.GITHUB_BRANCH || 'main', // default to main if provider branch is not set
   pactBrokerUrl = process.env.PACT_BROKER_BASE_URL,
   pactPayloadUrl = process.env.PACT_PAYLOAD_URL
 }: {

--- a/src/test-helpers/pact-utils/handle-url-and-selectors.ts
+++ b/src/test-helpers/pact-utils/handle-url-and-selectors.ts
@@ -184,12 +184,13 @@ function usePactBrokerUrlAndSelectors(
 /**
  * Builds an array of `ConsumerVersionSelector` objects for Pact verification.
  *
- * Generates selectors to determine which consumer pacts should be verified against the provider.
- * By default, it includes pacts from all branches of the consumer, including feature branches.
+ * This function generates selectors that determine which consumer pacts should be verified against the provider.
+ * By default, it includes pacts from all branches of the consumer, including feature branches and matching branches.
  * Optionally includes pacts from the consumer's `main` branch and deployed or released versions.
  *
  * @param consumer - The name of the consumer to verify against. If `undefined`, applies to all consumers.
- * @param includeMainAndDeployed - When `true` (default), includes `mainBranch` and `deployedOrReleased` selectors for broader verification. When `false`, only verifies pacts from branches matching the provider's branch.
+ * @param includeMainAndDeployed - When `true` (default), includes `mainBranch` and `deployedOrReleased` selectors for broader verification.
+ *                                 When `false`, only verifies pacts from all branches and matching branches.
  * @returns An array of `ConsumerVersionSelector` objects for Pact verification.
  *
  * @example
@@ -198,6 +199,7 @@ function usePactBrokerUrlAndSelectors(
  * // Result:
  * // [
  * //   { consumer: 'MoviesAPI', branch: '*' },
+ * //   { consumer: 'MoviesAPI', matchingBranch: true },
  * //   { consumer: 'MoviesAPI', mainBranch: true },
  * //   { consumer: 'MoviesAPI', deployedOrReleased: true }
  * // ]
@@ -207,6 +209,7 @@ function usePactBrokerUrlAndSelectors(
  * const selectors = buildConsumerVersionSelectors('MoviesAPI', false);
  * // Result:
  * // [
+ * //   { consumer: 'MoviesAPI', branch: '*' },
  * //   { consumer: 'MoviesAPI', matchingBranch: true }
  * // ]
  *
@@ -216,6 +219,7 @@ function usePactBrokerUrlAndSelectors(
  * // Result:
  * // [
  * //   { branch: '*' },
+ * //   { matchingBranch: true },
  * //   { mainBranch: true },
  * //   { deployedOrReleased: true }
  * // ]
@@ -225,7 +229,8 @@ function usePactBrokerUrlAndSelectors(
  * const selectors = buildConsumerVersionSelectors(undefined, false);
  * // Result:
  * // [
- * //   { branch: '*' }
+ * //   { branch: '*' },
+ * //   { matchingBranch: true }
  * // ]
  *
  * @see https://docs.pact.io/pact_broker/advanced_topics/consumer_version_selectors
@@ -234,25 +239,27 @@ function buildConsumerVersionSelectors(
   consumer: string | undefined,
   includeMainAndDeployed = true
 ): ConsumerVersionSelector[] {
-  // Create the base selector object. If a specific consumer is provided, include it in the selector.
+  // Create the base selector object.
+  // If a specific consumer is provided, include it in the selector.
   const baseSelector: Partial<ConsumerVersionSelector> = consumer
     ? { consumer }
     : {}
 
-  // If 'includeMainAndDeployed' is true (default case), include selectors for:
-  // - All branches of the consumer (branch: '*')
-  // - The main branch of the consumer (mainBranch: true)
-  // - Deployed or released versions of the consumer (deployedOrReleased: true)
+  // Start with selectors that always apply.
+  // - 'branch: "*"' includes all branches of the consumer.
+  // - 'matchingBranch: true' includes branches that match the provider's branch.
+  const selectors: ConsumerVersionSelector[] = [
+    { ...baseSelector, branch: '*' }, // Includes all branches of the consumer
+    { ...baseSelector, matchingBranch: true } // Includes matching branches
+  ]
+
   if (includeMainAndDeployed) {
-    return [
-      { ...baseSelector, branch: '*' }, // Includes all feature branches of the consumer
-      { ...baseSelector, mainBranch: true }, // Includes the main branch of the consumer
-      { ...baseSelector, deployedOrReleased: true } // Includes deployed or released consumer versions
-    ]
-  } else {
-    // If 'includeMainAndDeployed' is false, restrict the verification to the matching branch,
-    // which matches the provider's branch. This is useful when working with feature branches
-    // where both consumer and provider are working on the same feature.
-    return [{ ...baseSelector, matchingBranch: true }]
+    // If 'includeMainAndDeployed' is true (default case), include selectors for:
+    // - The main branch of the consumer (mainBranch: true)
+    // - Deployed or released versions of the consumer (deployedOrReleased: true)
+    selectors.push({ ...baseSelector, mainBranch: true }) // Includes the main branch of the consumer
+    selectors.push({ ...baseSelector, deployedOrReleased: true }) // Includes deployed or released consumer versions
   }
+
+  return selectors
 }


### PR DESCRIPTION
### Pact Breaking Change?

- [ ] Pact breaking change (check if this PR introduces a breaking change, which relaxes Pact verification to only run vs the matching branch of the consumer).
